### PR TITLE
Only F1 key returns to current slide

### DIFF
--- a/classic/PresentMode.cc
+++ b/classic/PresentMode.cc
@@ -115,8 +115,8 @@ void PresentMode::OnWindowMode(const std::string &_mode)
 /////////////////////////////////////////////////
 void PresentMode::OnKeyPress(ConstAnyPtr &_msg)
 {
-  Common::Instance()->HandleKeyPress(_msg->int_value());
-  this->ChangeKeyframe();
+  if (Common::Instance()->HandleKeyPress(_msg->int_value()))
+    this->ChangeKeyframe();
 }
 
 /////////////////////////////////////////////////

--- a/common/Common.cc
+++ b/common/Common.cc
@@ -51,10 +51,10 @@ void simslides::Common::LoadPluginSDF(const sdf::ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
-void simslides::Common::HandleKeyPress(int _key)
+bool simslides::Common::HandleKeyPress(int _key)
 {
   if (this->keyframes.empty())
-    return;
+    return false;
 
   // Next (right arrow on keyboard or presenter)
   if ((_key == 16777236 || _key == 16777239) &&
@@ -69,16 +69,19 @@ void simslides::Common::HandleKeyPress(int _key)
     this->currentKeyframe--;
   }
   // Current (F1)
-  else if (_key == 16777264)
+  else if (_key == 16777264 || _key == 16777304)
   {
+    // replay current frame
   }
   // Home (F6)
-  else if (_key == 16777269)
+  else if (_key == 16777269 || _key == 16777422)
   {
     this->currentKeyframe = -1;
   }
   else
-    return;
+    return false;
+
+  return true;
 }
 
 /////////////////////////////////////////////////

--- a/common/include/simslides/common/Common.hh
+++ b/common/include/simslides/common/Common.hh
@@ -46,7 +46,8 @@ namespace simslides
 
      /// \brief Handle an incoming key press from the user
      /// \param[in] _key Key as an integer
-     public: void HandleKeyPress(int _key);
+     /// \return True if key is handled, false if key should be ignored
+     public: bool HandleKeyPress(int _key);
 
      /// \brief Change to the given keyframe.
      /// If -1, go back to initial pose.

--- a/ignition/SimSlidesIgn.cc
+++ b/ignition/SimSlidesIgn.cc
@@ -189,8 +189,8 @@ void SimSlidesIgn::ProcessCommands()
 /////////////////////////////////////////////////
 void SimSlidesIgn::OnKeyPress(const ignition::msgs::Int32 &_msg)
 {
-  Common::Instance()->HandleKeyPress(_msg.data());
-  this->pendingCommand = true;
+  if (Common::Instance()->HandleKeyPress(_msg.data()))
+    this->pendingCommand = true;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Without this PR, most keys were returning to the current slide.

I'm not sure why the key codes for F1 and F6 are different for me now, so this is supporting both the old and the new codes.