### PR TITLE
Add colcon.pkg to automatically source setup

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,4 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+{
+  "hooks": ["share/simslides/setup.sh"]
+}


### PR DESCRIPTION
This makes it easier to use `ign gazebo` without `simslides_ignition` inside a colcon workspace (no need to source setup.sh)